### PR TITLE
Dashboard UI redesign with minimal Suunto-inspired style

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -43,6 +43,7 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-border-light: var(--border-light);
 }
 
 :root {
@@ -231,15 +232,9 @@
     @apply bg-gradient-to-r from-primary to-primary bg-clip-text text-transparent;
   }
 
-  /* Dashboard card - clean, minimal style */
+  /* Dashboard card - clean, minimal style with thin border */
   .dashboard-card {
-    @apply bg-white rounded-xl border border-border;
-    box-shadow: var(--card-shadow);
-    transition: box-shadow 0.2s ease;
-  }
-
-  .dashboard-card:hover {
-    box-shadow: var(--card-shadow-hover);
+    @apply rounded-xl border border-border;
   }
 
   /* Metric value - large numbers */

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -46,40 +46,64 @@
 }
 
 :root {
+  /* Primary colors */
   --primary: #0066CC;
   --primary-foreground: #FFFFFF;
   --sidebar-primary: #0052A3;
   --sidebar-primary-foreground: #FFFFFF;
-  --chart-1: #B3D9FF;
-  --chart-2: #4D94FF;
-  --chart-3: #0066CC;
-  --chart-4: #0052A3;
-  --chart-5: #003D7A;
 
-  --radius: 0.75rem;
+  /* Chart colors - Garmin style */
+  --chart-1: #00B4D8;  /* Cyan - primary metric */
+  --chart-2: #0077B6;  /* Blue - secondary metric */
+  --chart-3: #FF6B35;  /* Orange - calories/effort */
+  --chart-4: #DC2626;  /* Red - heart rate */
+  --chart-5: #10B981;  /* Green - positive/success */
+  --chart-blue: #00B4D8;
+  --chart-cyan: #00D4AA;
+  --chart-orange: #FF9500;
+  --chart-red: #FF3B30;
+  --chart-green: #34C759;
+  --chart-purple: #AF52DE;
+  --chart-gray: #8E8E93;
+
+  /* Layout */
+  --radius: 0.5rem;  /* Smaller radius for cleaner look */
+  --radius-card: 0.75rem;
+
+  /* Base colors */
   --background: #FFFFFF;
   --foreground: #1A1A1A;
-  --card: #F5F5F5;
+  --card: #FFFFFF;
   --card-foreground: #1A1A1A;
   --popover: #FFFFFF;
   --popover-foreground: #1A1A1A;
-  --secondary: #E8F0FF;
+  --secondary: #F8FAFC;
   --secondary-foreground: #0052A3;
-  --muted: #D9D9D9;
-  --muted-foreground: #666666;
+  --muted: #F1F5F9;
+  --muted-foreground: #64748B;
   --accent: #0066CC;
   --accent-foreground: #FFFFFF;
   --destructive: #DC2626;
   --destructive-foreground: #FFFFFF;
-  --border: #E5E5E5;
-  --input: #F5F5F5;
+
+  /* Borders - lighter for cleaner look */
+  --border: #E2E8F0;
+  --border-light: #F1F5F9;
+  --input: #F8FAFC;
   --ring: #0066CC;
+
+  /* Sidebar */
   --sidebar: #FFFFFF;
   --sidebar-foreground: #1A1A1A;
   --sidebar-accent: #E8F0FF;
   --sidebar-accent-foreground: #0052A3;
-  --sidebar-border: #E5E5E5;
+  --sidebar-border: #E2E8F0;
   --sidebar-ring: #0066CC;
+
+  /* Dashboard specific */
+  --dashboard-bg: #F8FAFC;
+  --card-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.05);
+  --card-shadow-hover: 0 4px 6px -1px rgb(0 0 0 / 0.07);
 }
 
 @layer base {
@@ -205,5 +229,60 @@
   /* Text gradient */
   .text-gradient {
     @apply bg-gradient-to-r from-primary to-primary bg-clip-text text-transparent;
+  }
+
+  /* Dashboard card - clean, minimal style */
+  .dashboard-card {
+    @apply bg-white rounded-xl border border-border;
+    box-shadow: var(--card-shadow);
+    transition: box-shadow 0.2s ease;
+  }
+
+  .dashboard-card:hover {
+    box-shadow: var(--card-shadow-hover);
+  }
+
+  /* Metric value - large numbers */
+  .metric-value {
+    @apply text-3xl md:text-4xl font-bold tracking-tight;
+    font-family: 'Geist', sans-serif;
+  }
+
+  .metric-value-sm {
+    @apply text-2xl font-bold tracking-tight;
+    font-family: 'Geist', sans-serif;
+  }
+
+  /* Metric label - subtle text */
+  .metric-label {
+    @apply text-sm text-muted-foreground font-medium;
+  }
+
+  /* Metric unit - smaller text after value */
+  .metric-unit {
+    @apply text-base font-normal text-muted-foreground ml-1;
+  }
+
+  /* Info icon button */
+  .info-icon {
+    @apply w-5 h-5 text-primary/60 hover:text-primary cursor-help transition-colors;
+  }
+
+  /* Divider - thin line */
+  .divider {
+    @apply border-t border-border-light;
+  }
+
+  /* Stat row - label and value inline */
+  .stat-row {
+    @apply flex items-center justify-between py-3 border-b border-border-light last:border-0;
+  }
+
+  .stat-row-label {
+    @apply text-sm text-muted-foreground;
+  }
+
+  .stat-row-value {
+    @apply text-sm font-semibold text-foreground;
   }
 }

--- a/resources/js/dashboard.js
+++ b/resources/js/dashboard.js
@@ -19,3 +19,35 @@ function closeSidebar() {
 toggle.addEventListener('click', openSidebar);
 closeBtn.addEventListener('click', closeSidebar);
 overlay.addEventListener('click', closeSidebar);
+
+// Swipe to open/close sidebar
+let touchStartX = 0;
+let touchStartY = 0;
+let touchEndX = 0;
+
+document.addEventListener('touchstart', (e) => {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+}, { passive: true });
+
+document.addEventListener('touchend', (e) => {
+    touchEndX = e.changedTouches[0].screenX;
+    const touchEndY = e.changedTouches[0].screenY;
+
+    const diffX = touchEndX - touchStartX;
+    const diffY = Math.abs(touchEndY - touchStartY);
+
+    // Swipe must be horizontal (diffX > diffY) and at least 80px
+    if (Math.abs(diffX) > 80 && diffX > diffY) {
+        const isSidebarOpen = !sidebar.classList.contains('-translate-x-full');
+
+        // Swipe right from left edge (< 50px) to open
+        if (diffX > 0 && touchStartX < 50 && !isSidebarOpen) {
+            openSidebar();
+        }
+        // Swipe left to close
+        else if (diffX < 0 && isSidebarOpen) {
+            closeSidebar();
+        }
+    }
+}, { passive: true });

--- a/resources/views/components/dashboard/empty-state.blade.php
+++ b/resources/views/components/dashboard/empty-state.blade.php
@@ -1,0 +1,72 @@
+@props([
+    'title',
+    'description' => null,
+    'icon' => 'activity',
+    'action' => null,
+    'actionText' => null,
+    'actionUrl' => null,
+    'actionDisabled' => false,
+])
+
+@php
+    $icons = [
+        'activity' => '<path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/>',
+        'chart' => '<polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/>',
+        'target' => '<circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>',
+        'calendar' => '<path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/>',
+        'settings' => '<circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>',
+    ];
+    $iconPath = $icons[$icon] ?? $icons['activity'];
+@endphp
+
+<div class="dashboard-card">
+    <div class="text-center py-12 px-6">
+        <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-muted flex items-center justify-center">
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="32"
+                height="32"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="text-muted-foreground"
+            >
+                {!! $iconPath !!}
+            </svg>
+        </div>
+
+        <h3 class="text-lg font-semibold text-foreground mb-2">{{ $title }}</h3>
+
+        @if($description)
+            <p class="text-sm text-muted-foreground mb-6 max-w-sm mx-auto">{{ $description }}</p>
+        @endif
+
+        @if($action)
+            {{ $action }}
+        @elseif($actionText)
+            @if($actionUrl && !$actionDisabled)
+                <a
+                    href="{{ $actionUrl }}"
+                    class="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg font-medium transition-colors"
+                >
+                    {{ $actionText }}
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M5 12h14"/>
+                        <path d="m12 5 7 7-7 7"/>
+                    </svg>
+                </a>
+            @else
+                <button
+                    type="button"
+                    class="inline-flex items-center gap-2 bg-primary text-white px-5 py-2.5 rounded-lg font-medium transition-colors {{ $actionDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-primary/90' }}"
+                    {{ $actionDisabled ? 'disabled' : '' }}
+                >
+                    {{ $actionText }}
+                </button>
+            @endif
+        @endif
+    </div>
+</div>

--- a/resources/views/components/dashboard/empty-state.blade.php
+++ b/resources/views/components/dashboard/empty-state.blade.php
@@ -19,8 +19,8 @@
     $iconPath = $icons[$icon] ?? $icons['activity'];
 @endphp
 
-<div class="dashboard-card">
-    <div class="text-center py-12 px-6">
+<div>
+    <div class="text-center py-16 px-6">
         <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-muted flex items-center justify-center">
             <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -50,18 +50,14 @@
             @if($actionUrl && !$actionDisabled)
                 <a
                     href="{{ $actionUrl }}"
-                    class="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg font-medium transition-colors"
+                    class="inline-flex items-center gap-2 text-sm bg-muted hover:bg-slate-200 text-foreground px-3 py-1.5 rounded-md font-medium border border-slate-300 transition-colors"
                 >
                     {{ $actionText }}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M5 12h14"/>
-                        <path d="m12 5 7 7-7 7"/>
-                    </svg>
                 </a>
             @else
                 <button
                     type="button"
-                    class="inline-flex items-center gap-2 bg-primary text-white px-5 py-2.5 rounded-lg font-medium transition-colors {{ $actionDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-primary/90' }}"
+                    class="inline-flex items-center gap-2 text-sm bg-muted hover:bg-slate-200 text-foreground px-3 py-1.5 rounded-md font-medium border border-slate-300 transition-colors {{ $actionDisabled ? 'opacity-50 cursor-not-allowed' : '' }}"
                     {{ $actionDisabled ? 'disabled' : '' }}
                 >
                     {{ $actionText }}
@@ -69,4 +65,4 @@
             @endif
         @endif
     </div>
-</div>
+

--- a/resources/views/components/dashboard/info-tooltip.blade.php
+++ b/resources/views/components/dashboard/info-tooltip.blade.php
@@ -1,0 +1,26 @@
+@props([
+    'text',
+])
+
+<button
+    type="button"
+    class="info-icon"
+    title="{{ $text }}"
+    aria-label="{{ $text }}"
+>
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+    >
+        <circle cx="12" cy="12" r="10"/>
+        <path d="M12 16v-4"/>
+        <path d="M12 8h.01"/>
+    </svg>
+</button>

--- a/resources/views/components/dashboard/metric-card.blade.php
+++ b/resources/views/components/dashboard/metric-card.blade.php
@@ -1,0 +1,49 @@
+@props([
+    'label',
+    'value',
+    'unit' => null,
+    'icon' => null,
+    'color' => 'primary',
+    'info' => null,
+])
+
+@php
+    $colorClasses = [
+        'primary' => 'text-primary',
+        'blue' => 'text-[var(--chart-blue)]',
+        'cyan' => 'text-[var(--chart-cyan)]',
+        'orange' => 'text-[var(--chart-orange)]',
+        'red' => 'text-[var(--chart-red)]',
+        'green' => 'text-[var(--chart-green)]',
+        'purple' => 'text-[var(--chart-purple)]',
+        'gray' => 'text-[var(--chart-gray)]',
+    ];
+    $valueColor = $colorClasses[$color] ?? $colorClasses['primary'];
+@endphp
+
+<div class="dashboard-card p-5">
+    <div class="flex items-start justify-between mb-3">
+        <span class="metric-label">{{ $label }}</span>
+        @if($info)
+            <x-dashboard.info-tooltip :text="$info" />
+        @endif
+    </div>
+
+    <div class="flex items-baseline gap-1">
+        @if($icon)
+            <span class="mr-2 {{ $valueColor }}">
+                {{ $icon }}
+            </span>
+        @endif
+        <span class="metric-value {{ $valueColor }}">{{ $value }}</span>
+        @if($unit)
+            <span class="metric-unit">{{ $unit }}</span>
+        @endif
+    </div>
+
+    @if($slot->isNotEmpty())
+        <div class="mt-3 pt-3 border-t border-border-light">
+            {{ $slot }}
+        </div>
+    @endif
+</div>

--- a/resources/views/components/dashboard/metric-card.blade.php
+++ b/resources/views/components/dashboard/metric-card.blade.php
@@ -21,8 +21,8 @@
     $valueColor = $colorClasses[$color] ?? $colorClasses['primary'];
 @endphp
 
-<div class="dashboard-card p-5">
-    <div class="flex items-start justify-between mb-3">
+<div class="py-4">
+    <div class="flex items-start justify-between mb-2">
         <span class="metric-label">{{ $label }}</span>
         @if($info)
             <x-dashboard.info-tooltip :text="$info" />
@@ -42,7 +42,7 @@
     </div>
 
     @if($slot->isNotEmpty())
-        <div class="mt-3 pt-3 border-t border-border-light">
+        <div class="mt-3 pt-3 border-t border-border">
             {{ $slot }}
         </div>
     @endif

--- a/resources/views/components/dashboard/section-card.blade.php
+++ b/resources/views/components/dashboard/section-card.blade.php
@@ -5,7 +5,7 @@
     'padding' => true,
 ])
 
-<div {{ $attributes->merge(['class' => 'dashboard-card']) }}>
+<div {{ $attributes->merge(['class' => 'pt-6']) }}>
     @if($title || $action)
         <div class="flex items-center justify-between p-5 {{ $slot->isNotEmpty() ? 'border-b border-border-light' : '' }}">
             <div>

--- a/resources/views/components/dashboard/section-card.blade.php
+++ b/resources/views/components/dashboard/section-card.blade.php
@@ -1,0 +1,32 @@
+@props([
+    'title' => null,
+    'subtitle' => null,
+    'action' => null,
+    'padding' => true,
+])
+
+<div {{ $attributes->merge(['class' => 'dashboard-card']) }}>
+    @if($title || $action)
+        <div class="flex items-center justify-between p-5 {{ $slot->isNotEmpty() ? 'border-b border-border-light' : '' }}">
+            <div>
+                @if($title)
+                    <h3 class="text-lg font-semibold text-foreground">{{ $title }}</h3>
+                @endif
+                @if($subtitle)
+                    <p class="text-sm text-muted-foreground mt-0.5">{{ $subtitle }}</p>
+                @endif
+            </div>
+            @if($action)
+                <div>
+                    {{ $action }}
+                </div>
+            @endif
+        </div>
+    @endif
+
+    @if($slot->isNotEmpty())
+        <div class="{{ $padding ? 'p-5' : '' }}">
+            {{ $slot }}
+        </div>
+    @endif
+</div>

--- a/resources/views/components/dashboard/stat-row.blade.php
+++ b/resources/views/components/dashboard/stat-row.blade.php
@@ -1,0 +1,21 @@
+@props([
+    'label',
+    'value',
+    'unit' => null,
+    'info' => null,
+])
+
+<div class="stat-row">
+    <div class="flex items-center gap-2">
+        <span class="stat-row-label">{{ $label }}</span>
+        @if($info)
+            <x-dashboard.info-tooltip :text="$info" />
+        @endif
+    </div>
+    <div class="flex items-baseline">
+        <span class="stat-row-value">{{ $value }}</span>
+        @if($unit)
+            <span class="text-xs text-muted-foreground ml-1">{{ $unit }}</span>
+        @endif
+    </div>
+</div>

--- a/resources/views/dashboard/activities.blade.php
+++ b/resources/views/dashboard/activities.blade.php
@@ -5,24 +5,11 @@
 @section('page-description', 'История всех ваших тренировок')
 
 @section('content')
-    <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-        <div class="text-center py-12">
-            <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="mx-auto text-slate-300 mb-4">
-                <path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/>
-            </svg>
-            <h3 class="text-xl font-semibold text-slate-900 mb-2">Нет активностей</h3>
-            <p class="text-slate-600 mb-6">Здесь будет отображаться история ваших тренировок</p>
-            <button
-                type="button"
-                class="bg-primary hover:bg-primary/90 text-white px-6 py-3 rounded-lg font-medium inline-flex items-center gap-2 transition-all opacity-50 cursor-not-allowed"
-                disabled
-            >
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M5 12h14"/>
-                    <path d="M12 5v14"/>
-                </svg>
-                Добавить активность
-            </button>
-        </div>
-    </div>
+    <x-dashboard.empty-state
+        title="Нет активностей"
+        description="Здесь будет отображаться история ваших тренировок"
+        icon="activity"
+        action-text="Добавить активность"
+        :action-disabled="true"
+    />
 @endsection

--- a/resources/views/dashboard/comparison.blade.php
+++ b/resources/views/dashboard/comparison.blade.php
@@ -5,25 +5,11 @@
 @section('page-description', 'Сравнение производительности между периодами')
 
 @section('content')
-    <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-        <div class="text-center py-12">
-            <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="mx-auto text-slate-300 mb-4">
-                <line x1="12" x2="12" y1="20" y2="10"/>
-                <line x1="18" x2="18" y1="20" y2="4"/>
-                <line x1="6" x2="6" y1="20" y2="16"/>
-            </svg>
-            <h3 class="text-xl font-semibold text-slate-900 mb-2">Недостаточно данных для сравнения</h3>
-            <p class="text-slate-600 mb-6">Нужно минимум 2 периода с активностями для сравнения</p>
-            <a
-                href="{{ route('dashboard.activities') }}"
-                class="bg-primary hover:bg-primary/90 text-white px-6 py-3 rounded-lg font-medium inline-flex items-center gap-2 transition-all"
-            >
-                Перейти к активностям
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M5 12h14"/>
-                    <path d="m12 5 7 7-7 7"/>
-                </svg>
-            </a>
-        </div>
-    </div>
+    <x-dashboard.empty-state
+        title="Недостаточно данных для сравнения"
+        description="Нужно минимум 2 периода с активностями для сравнения"
+        icon="chart"
+        action-text="Перейти к активностям"
+        :action-url="route('dashboard.activities')"
+    />
 @endsection

--- a/resources/views/dashboard/goals.blade.php
+++ b/resources/views/dashboard/goals.blade.php
@@ -5,25 +5,11 @@
 @section('page-description', 'Управление вашими целями по бегу')
 
 @section('content')
-    <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-        <div class="text-center py-12">
-            <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="mx-auto text-slate-300 mb-4">
-                <path d="m15.477 12.89 1.515 8.526a.5.5 0 0 1-.81.47l-3.58-2.687a1 1 0 0 0-1.197 0l-3.586 2.686a.5.5 0 0 1-.81-.469l1.514-8.526"/>
-                <circle cx="12" cy="8" r="6"/>
-            </svg>
-            <h3 class="text-xl font-semibold text-slate-900 mb-2">Нет целей</h3>
-            <p class="text-slate-600 mb-6">Создайте свою первую цель, чтобы отслеживать прогресс</p>
-            <button
-                type="button"
-                class="bg-primary hover:bg-primary/90 text-white px-6 py-3 rounded-lg font-medium inline-flex items-center gap-2 transition-all opacity-50 cursor-not-allowed"
-                disabled
-            >
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M5 12h14"/>
-                    <path d="M12 5v14"/>
-                </svg>
-                Создать цель
-            </button>
-        </div>
-    </div>
+    <x-dashboard.empty-state
+        title="Нет целей"
+        description="Создайте свою первую цель, чтобы отслеживать прогресс"
+        icon="target"
+        action-text="Создать цель"
+        :action-disabled="true"
+    />
 @endsection

--- a/resources/views/dashboard/overview.blade.php
+++ b/resources/views/dashboard/overview.blade.php
@@ -7,7 +7,7 @@
 @section('content')
     <div class="space-y-6">
         {{-- Metric Cards Grid --}}
-        <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <div class="grid grid-cols-2 lg:grid-cols-4 gap-6">
             <x-dashboard.metric-card
                 label="Тренировок"
                 value="—"
@@ -37,26 +37,30 @@
         </div>
 
         {{-- Weekly Activity Section --}}
-        <x-dashboard.section-card title="Активность за неделю">
+        <section>
+            <h3 class="text-lg font-semibold text-foreground mb-4">Активность за неделю</h3>
             <div class="h-48 flex items-center justify-center">
                 <p class="text-muted-foreground text-sm">Здесь будет график активности</p>
             </div>
-        </x-dashboard.section-card>
+        </section>
+
+        <hr class="border-border">
 
         {{-- Recent Activities Section --}}
-        <x-dashboard.section-card
-            title="Последние тренировки"
-            subtitle="За последние 7 дней"
-        >
-            <x-slot:action>
+        <section>
+            <div class="flex items-center justify-between mb-4">
+                <div>
+                    <h3 class="text-lg font-semibold text-foreground">Последние тренировки</h3>
+                    <p class="text-sm text-muted-foreground mt-0.5">За последние 7 дней</p>
+                </div>
                 <a href="{{ route('dashboard.activities') }}" class="text-sm text-primary hover:underline">
                     Все активности
                 </a>
-            </x-slot:action>
+            </div>
 
             <div class="text-center py-8">
                 <p class="text-muted-foreground text-sm">Нет тренировок за этот период</p>
             </div>
-        </x-dashboard.section-card>
+        </section>
     </div>
 @endsection

--- a/resources/views/dashboard/overview.blade.php
+++ b/resources/views/dashboard/overview.blade.php
@@ -5,7 +5,58 @@
 @section('page-description', 'Ваша статистика за неделю')
 
 @section('content')
-    <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-        <p class="text-slate-600">Здесь будет статистика тренировок.</p>
+    <div class="space-y-6">
+        {{-- Metric Cards Grid --}}
+        <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <x-dashboard.metric-card
+                label="Тренировок"
+                value="—"
+                color="primary"
+                info="Количество тренировок за эту неделю"
+            />
+            <x-dashboard.metric-card
+                label="Дистанция"
+                value="—"
+                unit="км"
+                color="blue"
+                info="Общая дистанция за неделю"
+            />
+            <x-dashboard.metric-card
+                label="Время"
+                value="—"
+                color="green"
+                info="Общее время тренировок"
+            />
+            <x-dashboard.metric-card
+                label="Ср. темп"
+                value="—"
+                unit="/км"
+                color="cyan"
+                info="Средний темп за неделю"
+            />
+        </div>
+
+        {{-- Weekly Activity Section --}}
+        <x-dashboard.section-card title="Активность за неделю">
+            <div class="h-48 flex items-center justify-center">
+                <p class="text-muted-foreground text-sm">Здесь будет график активности</p>
+            </div>
+        </x-dashboard.section-card>
+
+        {{-- Recent Activities Section --}}
+        <x-dashboard.section-card
+            title="Последние тренировки"
+            subtitle="За последние 7 дней"
+        >
+            <x-slot:action>
+                <a href="{{ route('dashboard.activities') }}" class="text-sm text-primary hover:underline">
+                    Все активности
+                </a>
+            </x-slot:action>
+
+            <div class="text-center py-8">
+                <p class="text-muted-foreground text-sm">Нет тренировок за этот период</p>
+            </div>
+        </x-dashboard.section-card>
     </div>
 @endsection

--- a/resources/views/dashboard/settings.blade.php
+++ b/resources/views/dashboard/settings.blade.php
@@ -5,360 +5,211 @@
 @section('page-description', 'Управление профилем и предпочтениями')
 
 @section('content')
-    <div class="space-y-6">
+    <div class="space-y-8">
         {{-- Avatar Section --}}
-        <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-            <h2 class="text-2xl font-bold text-slate-900 mb-6">Фото профиля</h2>
+        <section>
+            <h2 class="text-lg font-semibold text-foreground mb-4">Фото профиля</h2>
             <div class="flex items-center gap-6">
-                <div class="w-24 h-24 bg-primary rounded-full flex items-center justify-center">
-                    <span class="text-white font-bold text-3xl">
+                <div class="w-20 h-20 bg-primary rounded-full flex items-center justify-center">
+                    <span class="text-white font-bold text-2xl">
                         {{ strtoupper(substr(auth()->user()->email, 0, 2)) }}
                     </span>
                 </div>
                 <div>
-                    <p class="text-slate-600 mb-4">
-                        Загрузите фото профиля. Вы сможете обрезать и отрегулировать изображение перед сохранением.
+                    <p class="text-sm text-muted-foreground mb-3">
+                        Загрузите фото профиля
                     </p>
                     <button
                         type="button"
-                        class="bg-primary hover:bg-primary/90 text-white px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-all opacity-50 cursor-not-allowed"
+                        class="text-sm bg-muted hover:bg-slate-200 text-foreground px-3 py-1.5 rounded-md font-medium border border-slate-300 transition-colors opacity-50 cursor-not-allowed"
                         disabled
                     >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-                            <polyline points="17 8 12 3 7 8"/>
-                            <line x1="12" x2="12" y1="3" y2="15"/>
-                        </svg>
                         Выбрать фото
                     </button>
                 </div>
             </div>
-        </div>
+        </section>
+
+        <hr class="border-border">
 
         {{-- Personal Info Section --}}
-        <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-            <div class="flex items-center justify-between mb-6">
-                <h2 class="text-2xl font-bold text-slate-900">Личная информация</h2>
-                <button
-                    type="button"
-                    class="border border-slate-300 text-slate-700 hover:bg-slate-100 px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-all opacity-50 cursor-not-allowed"
-                    disabled
-                >
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
-                        <path d="m15 5 4 4"/>
-                    </svg>
-                    Редактировать
-                </button>
-            </div>
-
-            <div class="space-y-6">
-                {{-- Name Row --}}
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div>
-                        <p class="text-sm text-slate-600 font-medium mb-1">Имя</p>
-                        <p class="text-lg text-slate-900 font-semibold">—</p>
-                    </div>
-                    <div>
-                        <p class="text-sm text-slate-600 font-medium mb-1">Фамилия</p>
-                        <p class="text-lg text-slate-900 font-semibold">—</p>
-                    </div>
-                </div>
-
-                {{-- Contact Row --}}
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div class="flex items-start gap-3">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-primary mt-1">
-                            <rect width="20" height="16" x="2" y="4" rx="2"/>
-                            <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
-                        </svg>
-                        <div>
-                            <p class="text-sm text-slate-600 font-medium mb-1">Email</p>
-                            <p class="text-slate-900">{{ auth()->user()->email }}</p>
-                        </div>
-                    </div>
-                    <div class="flex items-start gap-3">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-green-600 mt-1">
-                            <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
-                        </svg>
-                        <div>
-                            <p class="text-sm text-slate-600 font-medium mb-1">Телефон</p>
-                            <p class="text-slate-900">Не указан</p>
-                        </div>
-                    </div>
-                </div>
-
-                {{-- Location & Birth Date Row --}}
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div class="flex items-start gap-3">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-orange-600 mt-1">
-                            <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/>
-                            <circle cx="12" cy="10" r="3"/>
-                        </svg>
-                        <div>
-                            <p class="text-sm text-slate-600 font-medium mb-1">Местоположение</p>
-                            <p class="text-slate-900">Не указано</p>
-                        </div>
-                    </div>
-                    <div class="flex items-start gap-3">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-purple-600 mt-1">
-                            <path d="M8 2v4"/>
-                            <path d="M16 2v4"/>
-                            <rect width="18" height="18" x="3" y="4" rx="2"/>
-                            <path d="M3 10h18"/>
-                        </svg>
-                        <div>
-                            <p class="text-sm text-slate-600 font-medium mb-1">Дата рождения</p>
-                            <p class="text-slate-900">Не указана</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        {{-- Physical Stats Section --}}
-        <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-            <div class="flex items-center justify-between mb-6">
-                <h2 class="text-2xl font-bold text-slate-900">Физические параметры</h2>
-                <button
-                    type="button"
-                    class="border border-slate-300 text-slate-700 hover:bg-slate-100 px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-all opacity-50 cursor-not-allowed"
-                    disabled
-                >
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
-                        <path d="m15 5 4 4"/>
-                    </svg>
-                    Редактировать
-                </button>
-            </div>
-
-            <div class="space-y-6">
-                {{-- Stats Cards --}}
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    <div class="bg-blue-50 rounded-xl p-6 border border-blue-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Рост</p>
-                        <p class="text-3xl font-bold text-blue-600">—</p>
-                        <p class="text-sm text-slate-600 mt-1">см</p>
-                    </div>
-
-                    <div class="bg-green-50 rounded-xl p-6 border border-green-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Вес</p>
-                        <p class="text-3xl font-bold text-green-600">—</p>
-                        <p class="text-sm text-slate-600 mt-1">кг</p>
-                    </div>
-
-                    <div class="bg-purple-50 rounded-xl p-6 border border-purple-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Возраст</p>
-                        <p class="text-3xl font-bold text-purple-600">—</p>
-                        <p class="text-sm text-slate-600 mt-1">лет</p>
-                    </div>
-                </div>
-
-                {{-- Gender & BMI --}}
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div class="bg-slate-50 rounded-xl p-6 border border-slate-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Пол</p>
-                        <p class="text-lg text-slate-900 font-semibold">Не указан</p>
-                    </div>
-
-                    <div class="bg-slate-50 rounded-xl p-6 border border-slate-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Индекс массы тела (BMI)</p>
-                        <p class="text-3xl font-bold text-slate-400">—</p>
-                    </div>
-                </div>
-
-                {{-- Heart Rate --}}
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div class="bg-orange-50 rounded-xl p-6 border border-orange-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Пульс в покое</p>
-                        <p class="text-3xl font-bold text-orange-600">—</p>
-                        <p class="text-sm text-slate-600 mt-1">уд/мин</p>
-                    </div>
-
-                    <div class="bg-red-50 rounded-xl p-6 border border-red-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Максимальный пульс</p>
-                        <p class="text-3xl font-bold text-red-600">—</p>
-                        <p class="text-sm text-slate-600 mt-1">уд/мин</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        {{-- Training Preferences Section --}}
-        <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-            <div class="flex items-center justify-between mb-6">
-                <h2 class="text-2xl font-bold text-slate-900">Предпочтения тренировок</h2>
-                <button
-                    type="button"
-                    class="border border-slate-300 text-slate-700 hover:bg-slate-100 px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-all opacity-50 cursor-not-allowed"
-                    disabled
-                >
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
-                        <path d="m15 5 4 4"/>
-                    </svg>
-                    Редактировать
-                </button>
-            </div>
-
-            <div class="space-y-6">
-                {{-- Distance & Time --}}
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div class="bg-blue-50 rounded-xl p-6 border border-blue-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Предпочитаемая дистанция</p>
-                        <p class="text-lg text-slate-900 font-semibold">Не указана</p>
-                    </div>
-
-                    <div class="bg-green-50 rounded-xl p-6 border border-green-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Предпочитаемое время</p>
-                        <p class="text-lg text-slate-900 font-semibold">Не указано</p>
-                    </div>
-                </div>
-
-                {{-- Days & Level --}}
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div class="bg-orange-50 rounded-xl p-6 border border-orange-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Дней тренировок в неделю</p>
-                        <p class="text-3xl font-bold text-orange-600">—</p>
-                    </div>
-
-                    <div class="bg-purple-50 rounded-xl p-6 border border-purple-200">
-                        <p class="text-sm text-slate-600 font-medium mb-2">Уровень опыта</p>
-                        <p class="text-lg text-slate-900 font-semibold">Не указан</p>
-                    </div>
-                </div>
-
-                {{-- Terrain Types --}}
-                <div>
-                    <p class="text-sm text-slate-600 font-medium mb-3">Любимые типы местности</p>
-                    <p class="text-slate-500">Не выбраны</p>
-                </div>
-
-                {{-- Toggles --}}
-                <div class="space-y-3 pt-4 border-t border-slate-200">
-                    <div class="flex items-center justify-between">
-                        <span class="text-slate-900 font-medium">Уведомления о тренировках</span>
-                        <div class="w-12 h-6 rounded-full bg-slate-300"></div>
-                    </div>
-                    <div class="flex items-center justify-between">
-                        <span class="text-slate-900 font-medium">Делиться результатами</span>
-                        <div class="w-12 h-6 rounded-full bg-slate-300"></div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        {{-- Account Settings Section --}}
-        <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-            <h2 class="text-2xl font-bold text-slate-900 mb-6">Управление аккаунтом</h2>
+        <section>
+            <h2 class="text-lg font-semibold text-foreground mb-4">Личная информация</h2>
 
             <div class="space-y-4">
-                {{-- Account Info --}}
-                <div class="bg-slate-50 rounded-xl p-6 border border-slate-200">
-                    <p class="text-sm text-slate-600 font-medium mb-2">Email аккаунта</p>
-                    <p class="text-lg text-slate-900 font-semibold">{{ auth()->user()->email }}</p>
-                    <p class="text-sm text-slate-500 mt-2">Используется для входа и восстановления пароля</p>
-                </div>
-
-                {{-- Security Section --}}
-                <div class="bg-blue-50 rounded-xl p-6 border border-blue-200">
-                    <div class="flex items-start gap-3">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-blue-600 mt-1">
-                            <rect width="18" height="11" x="3" y="11" rx="2" ry="2"/>
-                            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-                        </svg>
-                        <div class="flex-1">
-                            <h3 class="font-semibold text-slate-900 mb-2">Безопасность</h3>
-                            <p class="text-sm text-slate-600 mb-4">
-                                Измените пароль, чтобы защитить ваш аккаунт
-                            </p>
-                            <button
-                                type="button"
-                                class="bg-blue-600 text-white hover:bg-blue-700 px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-all opacity-50 cursor-not-allowed"
-                                disabled
-                            >
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                    <rect width="18" height="11" x="3" y="11" rx="2" ry="2"/>
-                                    <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-                                </svg>
-                                Изменить пароль
-                            </button>
-                        </div>
+                <div class="grid grid-cols-2 gap-8">
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Имя</p>
+                        <p class="text-sm text-foreground">—</p>
+                    </div>
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Фамилия</p>
+                        <p class="text-sm text-foreground">—</p>
                     </div>
                 </div>
-
-                {{-- Session Management --}}
-                <div class="bg-orange-50 rounded-xl p-6 border border-orange-200">
-                    <div class="flex items-start gap-3">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-orange-600 mt-1">
-                            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
-                            <polyline points="16 17 21 12 16 7"/>
-                            <line x1="21" x2="9" y1="12" y2="12"/>
-                        </svg>
-                        <div class="flex-1">
-                            <h3 class="font-semibold text-slate-900 mb-2">Сеанс</h3>
-                            <p class="text-sm text-slate-600 mb-4">
-                                Выйти из аккаунта на этом устройстве
-                            </p>
-                            <form action="{{ route('identity.logout') }}" method="POST" class="inline">
-                                @csrf
-                                <button
-                                    type="submit"
-                                    class="border border-orange-300 text-orange-700 hover:bg-orange-100 px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-all"
-                                >
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
-                                        <polyline points="16 17 21 12 16 7"/>
-                                        <line x1="21" x2="9" y1="12" y2="12"/>
-                                    </svg>
-                                    Выход
-                                </button>
-                            </form>
-                        </div>
+                <div class="grid grid-cols-2 gap-8">
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Email</p>
+                        <p class="text-sm text-foreground">{{ auth()->user()->email }}</p>
+                    </div>
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Телефон</p>
+                        <p class="text-sm text-foreground">—</p>
                     </div>
                 </div>
-
-                {{-- Danger Zone --}}
-                <div class="bg-red-50 rounded-xl p-6 border-2 border-red-200">
-                    <div class="flex items-start gap-3">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-red-600 mt-1">
-                            <circle cx="12" cy="12" r="10"/>
-                            <line x1="12" x2="12" y1="8" y2="12"/>
-                            <line x1="12" x2="12.01" y1="16" y2="16"/>
-                        </svg>
-                        <div class="flex-1">
-                            <h3 class="font-semibold text-slate-900 mb-2">Опасная зона</h3>
-                            <p class="text-sm text-slate-600 mb-4">
-                                Удаление аккаунта необратимо. Все ваши данные будут удалены.
-                            </p>
-                            <button
-                                type="button"
-                                class="bg-red-600 text-white hover:bg-red-700 px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-all opacity-50 cursor-not-allowed"
-                                disabled
-                            >
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                    <path d="M3 6h18"/>
-                                    <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
-                                    <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
-                                    <line x1="10" x2="10" y1="11" y2="17"/>
-                                    <line x1="14" x2="14" y1="11" y2="17"/>
-                                </svg>
-                                Удалить аккаунт
-                            </button>
-                        </div>
+                <div class="grid grid-cols-2 gap-8">
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Местоположение</p>
+                        <p class="text-sm text-foreground">—</p>
                     </div>
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Дата рождения</p>
+                        <p class="text-sm text-foreground">—</p>
+                    </div>
+                </div>
+                <div class="pt-2">
+                    <button
+                        type="button"
+                        class="text-sm bg-muted hover:bg-slate-200 text-foreground px-3 py-1.5 rounded-md font-medium border border-slate-300 transition-colors opacity-50 cursor-not-allowed"
+                        disabled
+                    >
+                        Редактировать
+                    </button>
                 </div>
             </div>
+        </section>
 
-            {{-- Security Tip --}}
-            <div class="mt-8 pt-6 border-t border-slate-200">
-                <div class="bg-slate-50 rounded-lg p-4">
-                    <p class="text-sm text-slate-600">
-                        <strong>Совет по безопасности:</strong> Никогда не делитесь своим паролем с кем-либо. Runtracker никогда не будет просить вас ввести пароль по электронной почте.
-                    </p>
+        <hr class="border-border">
+
+        {{-- Physical Stats Section --}}
+        <section>
+            <h2 class="text-lg font-semibold text-foreground mb-4">Физические параметры</h2>
+
+            <div class="space-y-4">
+                <div class="grid grid-cols-3 gap-8">
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Рост</p>
+                        <p class="text-sm text-foreground">— <span class="text-muted-foreground">см</span></p>
+                    </div>
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Вес</p>
+                        <p class="text-sm text-foreground">— <span class="text-muted-foreground">кг</span></p>
+                    </div>
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Возраст</p>
+                        <p class="text-sm text-foreground">— <span class="text-muted-foreground">лет</span></p>
+                    </div>
+                </div>
+                <div class="grid grid-cols-3 gap-8">
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Пол</p>
+                        <p class="text-sm text-foreground">—</p>
+                    </div>
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Пульс в покое</p>
+                        <p class="text-sm text-foreground">— <span class="text-muted-foreground">уд/мин</span></p>
+                    </div>
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Макс. пульс</p>
+                        <p class="text-sm text-foreground">— <span class="text-muted-foreground">уд/мин</span></p>
+                    </div>
+                </div>
+                <div class="pt-2">
+                    <button
+                        type="button"
+                        class="text-sm bg-muted hover:bg-slate-200 text-foreground px-3 py-1.5 rounded-md font-medium border border-slate-300 transition-colors opacity-50 cursor-not-allowed"
+                        disabled
+                    >
+                        Редактировать
+                    </button>
                 </div>
             </div>
-        </div>
+        </section>
+
+        <hr class="border-border">
+
+        {{-- Training Preferences Section --}}
+        <section>
+            <h2 class="text-lg font-semibold text-foreground mb-4">Предпочтения тренировок</h2>
+
+            <div class="space-y-4">
+                <div class="grid grid-cols-2 gap-8">
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Предпочитаемая дистанция</p>
+                        <p class="text-sm text-foreground">—</p>
+                    </div>
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Предпочитаемое время</p>
+                        <p class="text-sm text-foreground">—</p>
+                    </div>
+                </div>
+                <div class="grid grid-cols-2 gap-8">
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Дней тренировок в неделю</p>
+                        <p class="text-sm text-foreground">—</p>
+                    </div>
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-1">Уровень опыта</p>
+                        <p class="text-sm text-foreground">—</p>
+                    </div>
+                </div>
+                <div class="pt-2">
+                    <button
+                        type="button"
+                        class="text-sm bg-muted hover:bg-slate-200 text-foreground px-3 py-1.5 rounded-md font-medium border border-slate-300 transition-colors opacity-50 cursor-not-allowed"
+                        disabled
+                    >
+                        Редактировать
+                    </button>
+                </div>
+            </div>
+        </section>
+
+        <hr class="border-border">
+
+        {{-- Password Section --}}
+        <section>
+            <h2 class="text-lg font-semibold text-foreground mb-4">Пароль</h2>
+            <p class="text-sm text-muted-foreground mb-3">Обновите пароль для защиты аккаунта</p>
+            <button
+                type="button"
+                class="text-sm bg-muted hover:bg-slate-200 text-foreground px-3 py-1.5 rounded-md font-medium border border-slate-300 transition-colors opacity-50 cursor-not-allowed"
+                disabled
+            >
+                Изменить пароль
+            </button>
+        </section>
+
+        <hr class="border-border">
+
+        {{-- Session Section --}}
+        <section>
+            <h2 class="text-lg font-semibold text-foreground mb-4">Сессия</h2>
+            <p class="text-sm text-muted-foreground mb-3">Завершить текущую сессию на этом устройстве</p>
+            <form action="{{ route('identity.logout') }}" method="POST">
+                @csrf
+                <button
+                    type="submit"
+                    class="text-sm bg-muted hover:bg-slate-200 text-foreground px-3 py-1.5 rounded-md font-medium border border-slate-300 transition-colors"
+                >
+                    Выйти
+                </button>
+            </form>
+        </section>
+
+        <hr class="border-border">
+
+        {{-- Danger Zone --}}
+        <section>
+            <h2 class="text-lg font-semibold text-destructive mb-4">Удаление аккаунта</h2>
+            <p class="text-sm text-muted-foreground mb-3">Удаление необратимо, все данные будут потеряны</p>
+            <button
+                type="button"
+                class="text-sm bg-destructive/10 hover:bg-destructive/20 text-destructive px-3 py-1.5 rounded-md font-medium transition-colors opacity-50 cursor-not-allowed"
+                disabled
+            >
+                Удалить аккаунт
+            </button>
+        </section>
     </div>
 @endsection

--- a/resources/views/dashboard/stats.blade.php
+++ b/resources/views/dashboard/stats.blade.php
@@ -5,24 +5,11 @@
 @section('page-description', 'Детальный анализ вашей активности')
 
 @section('content')
-    <div class="bg-white rounded-2xl p-8 shadow-sm border border-slate-200">
-        <div class="text-center py-12">
-            <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="mx-auto text-slate-300 mb-4">
-                <polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/>
-                <polyline points="16 7 22 7 22 13"/>
-            </svg>
-            <h3 class="text-xl font-semibold text-slate-900 mb-2">Недостаточно данных</h3>
-            <p class="text-slate-600 mb-6">Добавьте несколько тренировок, чтобы увидеть статистику</p>
-            <a
-                href="{{ route('dashboard.activities') }}"
-                class="bg-primary hover:bg-primary/90 text-white px-6 py-3 rounded-lg font-medium inline-flex items-center gap-2 transition-all"
-            >
-                Перейти к активностям
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M5 12h14"/>
-                    <path d="m12 5 7 7-7 7"/>
-                </svg>
-            </a>
-        </div>
-    </div>
+    <x-dashboard.empty-state
+        title="Недостаточно данных"
+        description="Добавьте несколько тренировок, чтобы увидеть статистику"
+        icon="chart"
+        action-text="Перейти к активностям"
+        :action-url="route('dashboard.activities')"
+    />
 @endsection

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -6,7 +6,7 @@
     <title>@yield('title', 'Dashboard — Runtracker')</title>
     @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/dashboard.js'])
 </head>
-<body class="bg-[var(--dashboard-bg)]">
+<body class="bg-white">
 <div class="flex h-screen">
     {{-- Sidebar --}}
     <x-dashboard.sidebar />

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -6,20 +6,20 @@
     <title>@yield('title', 'Dashboard — Runtracker')</title>
     @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/dashboard.js'])
 </head>
-<body>
-<div class="flex h-screen bg-slate-50">
+<body class="bg-[var(--dashboard-bg)]">
+<div class="flex h-screen">
     {{-- Sidebar --}}
     <x-dashboard.sidebar />
 
     {{-- Main Content --}}
     <main class="flex-1 overflow-auto">
-        <div class="p-6 md:p-8 max-w-7xl mx-auto">
+        <div class="p-4 md:p-6 lg:p-8 max-w-7xl mx-auto">
             {{-- Page Header --}}
-            <div class="mb-8">
-                <h1 class="text-3xl md:text-4xl font-bold text-slate-900 mb-2 pl-12 md:pl-0">
+            <div class="mb-6">
+                <h1 class="text-2xl md:text-3xl font-bold text-foreground mb-1 pl-12 md:pl-0">
                     @yield('page-title')
                 </h1>
-                <p class="text-slate-600">
+                <p class="text-sm text-muted-foreground pl-12 md:pl-0">
                     @yield('page-description')
                 </p>
             </div>


### PR DESCRIPTION
## Summary

- Redesign dashboard UI with minimal Suunto-inspired style: white background, no card borders/shadows, thin divider lines
- Create reusable Blade components: metric-card, section-card, empty-state, stat-row, info-tooltip
- Unify button styles across all pages with muted background, slate border, and hover effect
- Redesign settings page with cleaner GitHub-style layout
- Add swipe gesture support for mobile sidebar (swipe right to open, left to close)